### PR TITLE
bump bollard and mockall dev dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bollard = "0.11.1"
+bollard = "0.12.0"
 bytes = "1.1.0"
 tonic = "0.7.0"
 tokio = "1.15.0"
 tower = "0.4"
 futures-util = "0.3.21"
+
+[dev-dependencies]
+mockall = "0.11.0"


### PR DESCRIPTION
Update bollard to the latest version (0.12.0) and add mockall dep which is used to create mocks for testing purposes as a dev dependency (meaning it isn't included in the build)