### PR TITLE
add basic rustler integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ tonic = "0.7.0"
 tokio = "1.15.0"
 tower = "0.4"
 futures-util = "0.3.21"
+rustler = "0.24.0"
+once_cell = "1.2.0"
 
 [dev-dependencies]
 mockall = "0.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,19 +16,23 @@
 # under the License.
 #
 [package]
-name = "funless-fn"
+name = "fn"
 version = "0.1.0"
 edition = "2021"
+
+[lib]
+path = "src/lib.rs"
+crate-type = ["cdylib", "lib"]
 
 [dependencies]
 bollard = "0.12.0"
 bytes = "1.1.0"
-tonic = "0.7.0"
-tokio = "1.15.0"
-tower = "0.4"
 futures-util = "0.3.21"
-rustler = "0.24.0"
 once_cell = "1.2.0"
+rustler = "0.24.0"
+tokio = "1.15.0"
+tonic = "0.7.0"
+tower = "0.4"
 
 [dev-dependencies]
 mockall = "0.11.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,3 +130,8 @@ pub async fn cleanup_container(docker: &Docker, container_name: &str) -> Result<
         .await?;
     Ok(())
 }
+
+rustler::init!(
+    "Elixir.Fn",
+    [nif::prepare_container, nif::run_function, nif::cleanup]
+);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+mod nif;
 
 use std::fs::File;
 use std::io::Read;

--- a/src/nif.rs
+++ b/src/nif.rs
@@ -1,17 +1,17 @@
 use crate::{connect_to_docker, get_image, setup_container};
-use bollard::errors::Error;
 use futures_util::TryFutureExt;
 use once_cell::sync::Lazy;
 use tokio::runtime::{Builder, Runtime};
 
 static TOKIO: Lazy<Runtime> = Lazy::new(|| {
     Builder::new_current_thread()
+        .enable_all()
         .build()
         .expect("Failed to start tokio runtime")
 });
 
 #[rustler::nif]
-fn prepare_container() -> () {
+fn prepare_container() -> i64 {
     let container_name = "funless-node-container";
     let image_name = "node:lts-alpine";
     let tar_file = "./hello.tar.gz";
@@ -24,6 +24,8 @@ fn prepare_container() -> () {
     });
 
     let _result = TOKIO.block_on(f);
+
+    0
 }
 
 #[rustler::nif]
@@ -31,5 +33,3 @@ fn run_function() {}
 
 #[rustler::nif]
 fn cleanup() {}
-
-rustler::init!("Elixir.Fn", [prepare_container, run_function, cleanup]);

--- a/src/nif.rs
+++ b/src/nif.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
 use crate::{connect_to_docker, get_image, setup_container};
 use futures_util::TryFutureExt;
 use once_cell::sync::Lazy;

--- a/src/nif.rs
+++ b/src/nif.rs
@@ -1,0 +1,35 @@
+use crate::{connect_to_docker, get_image, setup_container};
+use bollard::errors::Error;
+use futures_util::TryFutureExt;
+use once_cell::sync::Lazy;
+use tokio::runtime::{Builder, Runtime};
+
+static TOKIO: Lazy<Runtime> = Lazy::new(|| {
+    Builder::new_current_thread()
+        .build()
+        .expect("Failed to start tokio runtime")
+});
+
+#[rustler::nif]
+fn prepare_container() -> () {
+    let container_name = "funless-node-container";
+    let image_name = "node:lts-alpine";
+    let tar_file = "./hello.tar.gz";
+    let main_file = "/opt/index.js";
+
+    let docker = connect_to_docker("/run/user/1001/docker.sock")
+        .expect("Failed to connect to docker socket");
+    let f = get_image(&docker, "node:lts-alpine").and_then(|_| {
+        setup_container(&docker, &container_name, &image_name, &main_file, &tar_file)
+    });
+
+    let _result = TOKIO.block_on(f);
+}
+
+#[rustler::nif]
+fn run_function() {}
+
+#[rustler::nif]
+fn cleanup() {}
+
+rustler::init!("Elixir.Fn", [prepare_container, run_function, cleanup]);

--- a/tests/test_hello.rs
+++ b/tests/test_hello.rs
@@ -20,7 +20,7 @@ use bollard::{
     errors::Error,
 };
 use bytes::Bytes;
-use funless_fn::{
+use r#fn::{
     cleanup_container, connect_to_docker, container_logs, get_image, setup_container,
     wait_container,
 };


### PR DESCRIPTION
Add placeholder functions executing steps in the container init-run-cleanup pipeline and export them as Erlang NIFs via rustler.

Change Cargo.toml configuration to allow rustler integration.