### PR TITLE
Rustler integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
+name = "fn"
 path = "src/lib.rs"
 crate-type = ["cdylib", "lib"]
 

--- a/src/atoms.rs
+++ b/src/atoms.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
 rustler::atoms! {
     ok,
     error

--- a/src/atoms.rs
+++ b/src/atoms.rs
@@ -1,0 +1,4 @@
+rustler::atoms! {
+    ok,
+    error
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+mod atoms;
 mod nif;
 
 use std::fs::File;

--- a/src/nif.rs
+++ b/src/nif.rs
@@ -15,14 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 //
+
 use crate::{
+    atoms::{error, ok},
     cleanup_container, connect_to_docker, container_logs, get_image, setup_container,
     wait_container,
 };
 use bollard::container::StartContainerOptions;
 use futures_util::TryFutureExt;
 use once_cell::sync::Lazy;
-use std::{env, path::Path};
+use rustler::{Encoder, Env, OwnedEnv};
+use std::{env, path::Path, thread};
 use tokio::runtime::{Builder, Runtime};
 
 static TOKIO: Lazy<Runtime> = Lazy::new(|| {
@@ -33,59 +36,77 @@ static TOKIO: Lazy<Runtime> = Lazy::new(|| {
 });
 
 #[rustler::nif]
-fn prepare_container() -> String {
+fn prepare_container(
+    env: Env,
+    container_name: String,
+    image_name: String,
+    tar_path: String,
+    main_file: String,
+) {
+    let pid = env.pid();
     let project_path = Path::new(env!("CARGO_MANIFEST_DIR"));
 
-    let container_name = "funless-node-container";
-    let image_name = "node:lts-alpine";
-    let tar_file = project_path.join("js/hello.tar.gz").display().to_string();
-    let main_file = "/opt/index.js";
+    let tar_file = project_path.join(tar_path).display().to_string();
 
-    let docker = connect_to_docker("/run/user/1001/docker.sock")
-        .expect("Failed to connect to docker socket");
-    let f = get_image(&docker, "node:lts-alpine").and_then(|_| {
-        setup_container(&docker, &container_name, &image_name, &main_file, &tar_file)
+    thread::spawn(move || {
+        let mut thread_env = OwnedEnv::new();
+        let docker = connect_to_docker("/run/user/1001/docker.sock")
+            .expect("Failed to connect to docker socket");
+        let f = get_image(&docker, "node:lts-alpine").and_then(|_| {
+            setup_container(&docker, &container_name, &image_name, &main_file, &tar_file)
+        });
+
+        let result = TOKIO.block_on(f);
+
+        match result {
+            Ok(()) => thread_env.send_and_clear(&pid, |env| ok().encode(env)),
+            Err(e) => thread_env.send_and_clear(&pid, |env| (error(), e.to_string()).encode(env)),
+        }
     });
-
-    let result = TOKIO.block_on(f);
-
-    match result {
-        Ok(()) => "ok".to_string(),
-        Err(e) => e.to_string(),
-    }
 }
 
 #[rustler::nif]
-fn run_function() -> String {
-    let container_name = "funless-node-container";
+fn run_function(env: Env, container_name: String) {
+    let pid = env.pid();
+    // let container_name = "funless-node-container";
 
-    let docker = connect_to_docker("/run/user/1001/docker.sock")
-        .expect("Failed to connect to docker socket");
+    thread::spawn(move || {
+        let mut thread_env = OwnedEnv::new();
+        let docker = connect_to_docker("/run/user/1001/docker.sock")
+            .expect("Failed to connect to docker socket");
 
-    let f = docker
-        .start_container(container_name, None::<StartContainerOptions<String>>)
-        .and_then(|_| wait_container(&docker, &container_name))
-        .and_then(|_| container_logs(&docker, &container_name));
+        let f = docker
+            .start_container(&container_name, None::<StartContainerOptions<String>>)
+            .and_then(|_| wait_container(&docker, &container_name))
+            .and_then(|_| container_logs(&docker, &container_name));
 
-    let logs = TOKIO.block_on(f);
+        let result = TOKIO.block_on(f);
 
-    match logs {
-        Ok(v) => v[0].to_string(),
-        Err(e) => e.to_string(),
-    }
+        match result {
+            Ok(v) => {
+                let logs = v.iter().map(|l| l.to_string()).collect::<Vec<String>>();
+                thread_env.send_and_clear(&pid, |env| (ok(), logs).encode(env))
+            }
+            Err(e) => thread_env.send_and_clear(&pid, |env| (error(), e.to_string()).encode(env)),
+        };
+    });
 }
 
 #[rustler::nif]
-fn cleanup() -> String {
-    let container_name = "funless-node-container";
+fn cleanup(env: Env, container_name: String) {
+    let pid = env.pid();
+    // let container_name = "funless-node-container";
 
-    let docker = connect_to_docker("/run/user/1001/docker.sock")
-        .expect("Failed to connect to docker socket");
+    thread::spawn(move || {
+        let mut thread_env = OwnedEnv::new();
+        let docker = connect_to_docker("/run/user/1001/docker.sock")
+            .expect("Failed to connect to docker socket");
 
-    let result = TOKIO.block_on(cleanup_container(&docker, container_name));
+        let result = TOKIO.block_on(cleanup_container(&docker, &container_name));
 
-    match result {
-        Ok(()) => "ok".to_string(),
-        Err(e) => e.to_string(),
-    }
+        match result {
+            Ok(()) => thread_env.send_and_clear(&pid, |env| ok().encode(env)),
+            Err(e) => thread_env.send_and_clear(&pid, |env| (error(), e.to_string()).encode(env)),
+        }
+    });
 }


### PR DESCRIPTION
This PR adds three NIFs (`prepare_container`, `run_function` and `cleanup`) to be used by funless-worker.
The NIFs are executed on a separate thread and send a message to the calling process when done.

This PR closes #11.